### PR TITLE
Simplify git clone command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To clone this repository to your local machine, follow these steps:
 3. Use the following command to clone the repository:
 
 ```bash
-git clone (https://github.com/ansarshaik965/AWS_DEVOPS_CICD)
+git clone https://github.com/ansarshaik965/AWS_DEVOPS_CICD
 ```
 
 


### PR DESCRIPTION
This pull request simplifies the git clone command in the README.md file by removing the unnecessary brackets. This change makes it easier for users to copy and paste the command without having to edit it, thereby improving the user experience for those setting up the project.